### PR TITLE
acro_master.lua - Updated delay from 500 to 3000 before looking for acro timer. 

### DIFF
--- a/VeggieTales/luaScripts/acro_master.lua
+++ b/VeggieTales/luaScripts/acro_master.lua
@@ -192,7 +192,7 @@ function doMoves()
 					  skip = true;
 		    			end
 			    	  statusScreen(status .. GUI);
-				  lsSleep(500);
+				  lsSleep(3000);
 			   end --if #acro == 2
 
 		       end --while acroTimer


### PR DESCRIPTION
Acro: You are going too fast fixed. Macro should now work as intended. When macro clicked on an acro move, there was a long delay, before the acro timer, acually appears on the game screen. This should fix that.
