### PR TITLE
Cleaning House

### DIFF
--- a/VeggieTales/luaScripts/acro_master.lua
+++ b/VeggieTales/luaScripts/acro_master.lua
@@ -199,6 +199,7 @@ function doMoves()
 					  --srSetMousePos(clickMove[0], clickMove[1]-1);
 					  status = checkedMovesName[i] .. " clicked";
 					  currentClick = currentClick + 1;
+					  lsSleep(200);
 					else
 					  status = "BUTTON NOT FOUND!\nSkipping: " .. checkedMovesName[i];
 					  skip = true;

--- a/VeggieTales/luaScripts/single_click_stat_mon.lua
+++ b/VeggieTales/luaScripts/single_click_stat_mon.lua
@@ -7,7 +7,8 @@ assert(loadfile("luaScripts/common.inc"))();
 
 askText = singleLine([[
   Stat Clicker v1.1 (Revised by Tallow) --
-  Move mouse to a spot you want clicked and press shift.
+  This macro will watch your skills window and only click when you are not tired.
+  Move mouse to a spot you want clicked and press shift to repeat clicks when not tired.
 ]]);
 
 smallWarning = singleLine([[


### PR DESCRIPTION
gather.lua added a small delay to prevent "Unable to find the Cartographer's Cam item." error message from occuring
test_ocr_clock.lua - New example script that demonstrates how to parse the egypt clock and fetch coordinates, egypt date, time
flax_seeds.lua renamed to flax_seeds.lua.old
flax_stable_old.lua renamed to flax_stable_old.lua.old
windows_arranger.lua - adjusted num_high variables on all projects. Originally tweaked with 1280x1024. Lowered in case someone uses 1400x900 (common), which would cause window at bottom of screen to overlap. Also takes into consideration guilded buildings with an extra line of text. Fixed Thistle Custom grid.
windows_unpin.lua - added a statusScreen message while macro is working.
single_click_stat_mon.lua - Added extra description to the askforWindow screen
run_for_slate.lua renamed to slate.lua
onions.lua renamed to onions.lua.old
onions2.lua renamed to onions2.lua.old
window_opener.lua - added checkBreak();
pyramid.lua renamed to pyramid_TapRod.lua
mining_sand.lua renamed to mining_gems.lua

-- These were not included in last update, repeating update with below items...

acro_master.lua - Added delay after move clicks in an attempt to prevent the very rare "You are going too fast" message.
