### PR TITLE
Cleaning House

### DIFF
--- a/VeggieTales/luaScripts/fishing.lua
+++ b/VeggieTales/luaScripts/fishing.lua
@@ -575,48 +575,53 @@ function gui_refresh()
 
       lsSetCamera(0,0,lsScreenX*1.6,lsScreenY*1.6);
 
-    if lsButtonText(lsScreenX + 60, lsScreenY - 10, 0, 110, 0xFFFFFFff,
+    if lsButtonText(lsScreenX + 40, lsScreenY - 10, 0, 130, 0xFFFFFFff,
                     "Options") then
 	setResume = true;
 	setOptions();
     end
 
 	if not setPause then
-    if lsButtonText(lsScreenX + 60, lsScreenY + 20, 0, 110, 0xFFFFFFff,
+    if lsButtonText(lsScreenX + 40, lsScreenY + 20, 0, 130, 0xFFFFFFff,
                     "Pause") then
 	setPause = true;
     end
 	end
 
-    if lsButtonText(lsScreenX + 60, lsScreenY + 50, 0, 110, 0xFFFFFFff,
+    if lsButtonText(lsScreenX + 40, lsScreenY + 50, 0, 130, 0xFFFFFFff,
                     "End Script") then
       error(quitMessage);
     end
 
 	if skipLure then
-	skipLureText = "Wait!";
+	skipLureText = "Skipping...";
 	skipLureTextColor = 0xffff40ff;
 	else
-	skipLureText = "Next Lure";
+	skipLureText = "Skip Lure";
 	skipLureTextColor = 0xFFFFFFff;
 	end
 
-    if lsButtonText(lsScreenX + 60, lsScreenY + 150, 0, 110, skipLureTextColor,
+    if lsButtonText(lsScreenX + 40, lsScreenY + 150, 0, 130, skipLureTextColor,
                     skipLureText	) then
+		if skipLure == false then
 	skipLure = true;
+		else
+	skipLure = false;
+		end
+
     end
 
 
 	if LockLure then
 	LockLureColor =  0xffff40ff;
-	LockLureText =  "Locked!";
+	LockLureText =  "Lure Locked!";
 	else
 	LockLureColor = 0xFFFFFFff;
 	LockLureText = "Lock Lure";
 	end
 
 
-    if lsButtonText(lsScreenX + 60, lsScreenY + 180, 0, 110, LockLureColor,
+    if lsButtonText(lsScreenX + 40, lsScreenY + 180, 0, 130, LockLureColor,
                     LockLureText ) then
 	if LockLure then
 	LockLure =  false;
@@ -741,6 +746,7 @@ function doit()
 			--Switch Lures
 			UseLure();
 			skipLure = false;
+			LockLure = false;
 			GrandTotalLuresUsed = GrandTotalLuresUsed + 1;
 			
 			--update log


### PR DESCRIPTION
gather.lua added a small delay to prevent "Unable to find the Cartographer's Cam item." error message from occuring
test_ocr_clock.lua - New example script that demonstrates how to parse the egypt clock and fetch coordinates, egypt date, time
flax_seeds.lua renamed to flax_seeds.lua.old
flax_stable_old.lua renamed to flax_stable_old.lua.old
windows_arranger.lua - adjusted num_high variables on all projects. Originally tweaked with 1280x1024. Lowered in case someone uses 1400x900 (common), which would cause window at bottom of screen to overlap. Also takes into consideration guilded buildings with an extra line of text. Fixed Thistle Custom grid.
windows_unpin.lua - added a statusScreen message while macro is working.
single_click_stat_mon.lua - Added extra description to the askforWindow screen
run_for_slate.lua renamed to slate.lua
onions.lua renamed to onions.lua.old
onions2.lua renamed to onions2.lua.old
window_opener.lua - added checkBreak();
pyramid.lua renamed to pyramid_TapRod.lua
mining_sand.lua renamed to mining_gems.lua
acro_master.lua - Added delay after move clicks in an attempt to prevent the very rare "You are going too fast" message.
-- Same updates, but one last final update to fishing, sorry bout that!

fishing.lua - minor bug fixes, misc enhancements
